### PR TITLE
Bump golang to `v1.21`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TFTP server and client library for Golang
 =========================================
 
-[![GoDoc](https://godoc.org/github.com/pin/tftp/v3?status.svg)](https://godoc.org/github.com/pin/tftp/v3)
+[![GoDoc](https://godoc.org/github.com/damyan/tftp-new/v3?status.svg)](https://godoc.org/github.com/damyan/tftp-new/v3)
 
 Implements:
  * [RFC 1350](https://tools.ietf.org/html/rfc1350) - The TFTP Protocol (Revision 2)
@@ -14,7 +14,7 @@ Partially implements (tsize server side only):
 Set of features is sufficient for PXE boot support.
 
 ``` go
-import "github.com/pin/tftp/v3"
+import "github.com/damyan/tftp-new/v3"
 ```
 
 The package is cohesive to Golang `io`. Particularly it implements

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
-module github.com/pin/tftp/v3
+module github.com/damyan/tftp-new/v3
 
-go 1.13
+go 1.21
 
 require golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+
+require golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect

--- a/receiver.go
+++ b/receiver.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pin/tftp/v3/netascii"
+	"github.com/damyan/tftp-new/v3/netascii"
 )
 
 // IncomingTransfer provides methods that expose information associated with

--- a/sender.go
+++ b/sender.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pin/tftp/v3/netascii"
+	"github.com/damyan/tftp-new/v3/netascii"
 )
 
 // OutgoingTransfer provides methods to set the outgoing transfer size and


### PR DESCRIPTION
Change refence to `github.com/damyan/tftp-new v3`, will be set to `github.com/damyan/tftp v3`, when ready